### PR TITLE
Fix small typo on self._homeY

### DIFF
--- a/IPythonDisplayTurtle/__init__.py
+++ b/IPythonDisplayTurtle/__init__.py
@@ -214,7 +214,7 @@ class Snake():
         self.goto(newX, newY)
     
     def home(self):
-        self.goto(self._homeX, self.homeY)
+        self.goto(self._homeX, self._homeY)
         self.setheading(0)
         
     def pos(self):

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="IPythonDisplayTurtle", # Replace with your own username
-    version="0.0.33",
+    version="0.0.34",
     author="Atahan Ozturk",
     author_email="atahan012000@gmail.com",
     description="Turtles using IPython Display",


### PR DESCRIPTION
Fixes a small typo in the `home()` method